### PR TITLE
Added South migrations

### DIFF
--- a/djmail/south_migrations/0001_initial.py
+++ b/djmail/south_migrations/0001_initial.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'Message'
+        db.create_table(u'djmail_message', (
+            ('uuid', self.gf('django.db.models.fields.CharField')(default='e4fca98e-8cff-11e4-92de-70188bfc3fc1', max_length=40, primary_key=True)),
+            ('from_email', self.gf('django.db.models.fields.CharField')(max_length=1024, blank=True)),
+            ('to_email', self.gf('django.db.models.fields.TextField')(blank=True)),
+            ('body_text', self.gf('django.db.models.fields.TextField')(blank=True)),
+            ('body_html', self.gf('django.db.models.fields.TextField')(blank=True)),
+            ('subject', self.gf('django.db.models.fields.CharField')(max_length=1024, blank=True)),
+            ('data', self.gf('django.db.models.fields.TextField')(blank=True)),
+            ('retry_count', self.gf('django.db.models.fields.SmallIntegerField')(default=-1)),
+            ('status', self.gf('django.db.models.fields.SmallIntegerField')(default=10)),
+            ('priority', self.gf('django.db.models.fields.SmallIntegerField')(default=50)),
+            ('created_at', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
+            ('sent_at', self.gf('django.db.models.fields.DateTimeField')(default=None, null=True)),
+            ('exception', self.gf('django.db.models.fields.TextField')(blank=True)),
+        ))
+        db.send_create_signal(u'djmail', ['Message'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'Message'
+        db.delete_table(u'djmail_message')
+
+
+    models = {
+        u'djmail.message': {
+            'Meta': {'ordering': "[u'created_at']", 'object_name': 'Message'},
+            'body_html': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'body_text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'data': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'exception': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'from_email': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'blank': 'True'}),
+            'priority': ('django.db.models.fields.SmallIntegerField', [], {'default': '50'}),
+            'retry_count': ('django.db.models.fields.SmallIntegerField', [], {'default': '-1'}),
+            'sent_at': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True'}),
+            'status': ('django.db.models.fields.SmallIntegerField', [], {'default': '10'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'blank': 'True'}),
+            'to_email': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'default': "'e4fd26de-8cff-11e4-92de-70188bfc3fc1'", 'max_length': '40', 'primary_key': 'True'})
+        }
+    }
+
+    complete_apps = ['djmail']

--- a/doc/djmail.asciidoc
+++ b/doc/djmail.asciidoc
@@ -59,6 +59,14 @@ DJMAIL_REAL_BACKEND="django.core.mail.backends.console.EmailBackend"
 This specifies: emails are managed by djmail default backend and sent using
 console based django builtin backend.
 
+If your project is using South consider to include the following line in your settings file:
+
+----
+SOUTH_MIGRATION_MODULES = {
+    'djmail': 'djmail.south_migrations',
+}
+----
+
 How to use?
 ~~~~~~~~~~~
 


### PR DESCRIPTION
For non 1.7 Django projects South is needed to manage database
migrations.
Also docs got updated to include a hint on how to make this migration
work.