### PR TITLE
add missing license declaration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     url="https://github.com/niwibe/djmail",
     author="Andrey Antukh",
     author_email="niwi@niwi.be",
+    license='BSD',
     version="0.10.0",
     packages=find_packages(exclude=['contrib', 'docs', 'test*']),
     description=description.strip(),


### PR DESCRIPTION
It's in the classifiers but running `python setup.py --license` doesn't return BSD.